### PR TITLE
Change RN version dependency to  0.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   },
   "homepage": "https://github.com/marudy/react-native-responsive-screen#readme",
   "peerDependencies": {
-    "react-native": "^0.45.1"
+    "react-native": "^0.35"
   }
 }


### PR DESCRIPTION
Resolves #10 

Change RN version dependency to 0.35. It's the earliest that we have tested with although there should be no problem with earlier versions as well, since the package is only JavaScript and not native.