### PR TITLE
Fix an issue where screenWidth and screenHeight could be zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@
 import { Dimensions, PixelRatio } from 'react-native';
 
 // Retrieve initial screen's width
-let screenWidth = Dimensions.get('window').width;
+let screenWidth = Dimensions.get('window').width || Dimensions.get('screen').width;
 
 // Retrieve initial screen's height
-let screenHeight = Dimensions.get('window').height;
+let screenHeight = Dimensions.get('window').height || Dimensions.get('screen').height;
 
 /**
  * Converts provided width percentage to independent pixel (dp).


### PR DESCRIPTION
Often screenWidth and screenHeight are 0, because Dimensions.get('window') doesn't return the actual dimensions.
If so, try to use Dimensions.get('screen').