### PR TITLE
rename widthPercentageToDp and heightPercentageToDp and add standard style lint to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ Check out [this medium article](https://medium.com/react-native-training/build-r
 
 # Usage
 * After the package has installed, when application loads (in real device and/or emulator), it detects the screen's width and height. I.e. for Samsung A5 2017 model it detects `width: 360DP` and `height: 640DP` (these are the values without taking into account the device's scale factor).
-* The package exposes 2 basic methods: `widthPercentageToDP` and `heightPercentageToDP`. Their names essentially mean that you can supply a "percentage like" string value to each method and it will return the DP (indipendent pixel) that correspond to the supplied percentage of current screen's width/height respectivelly. I.e. for Samsung A5 2017, if we supply to a CSS box: `width: widthPercentageToDP('53%')`, the rendered style will be `width: 190.8` DP. Check example number 1 for how to use them.
-* Methods `widthPercentageToDP` and `heightPercentageToDP` can be used for any style (CSS) property that accepts DP as value. DP values are the ones of type `number` over the props mentioned in RN docs: [View style props](https://facebook.github.io/react-native/docs/view-style-props.html), [Text style props](https://facebook.github.io/react-native/docs/text-style-props.html), [Image style props](https://facebook.github.io/react-native/docs/image-style-props.html), [Layout props](https://facebook.github.io/react-native/docs/layout-props.html) and [Shadow props](https://facebook.github.io/react-native/docs/shadow-props.html). Use the exposed methods for all of the type `number` properties used in your app in order to make your app fully responsive for all screen sizes.
-* You can also provide decimal values to these 2 methods, i.e. `font-size: widthPercentageToDP('3.75%')`.
+* The package exposes 2 basic methods: `wp` and `hp`. Their names essentially mean that you can supply a "percentage like" string value to each method and it will return the DP (indipendent pixel) that correspond to the supplied percentage of current screen's width/height respectivelly. I.e. for Samsung A5 2017, if we supply to a CSS box: `width: wp('53%')`, the rendered style will be `width: 190.8` DP. Check example number 1 for how to use them.
+* Methods `wp` and `hp` can be used for any style (CSS) property that accepts DP as value. DP values are the ones of type `number` over the props mentioned in RN docs: [View style props](https://facebook.github.io/react-native/docs/view-style-props.html), [Text style props](https://facebook.github.io/react-native/docs/text-style-props.html), [Image style props](https://facebook.github.io/react-native/docs/image-style-props.html), [Layout props](https://facebook.github.io/react-native/docs/layout-props.html) and [Shadow props](https://facebook.github.io/react-native/docs/shadow-props.html). Use the exposed methods for all of the type `number` properties used in your app in order to make your app fully responsive for all screen sizes.
+* You can also provide decimal values to these 2 methods, i.e. `font-size: wp('3.75%')`.
 * The package methods can be used with or without flex depending on what you want to do and how you choose to implement it.
 * The suggested approach is to start developing from larger screens (i.e. tablets). That way you are less prone to forget adding responsive values for all properties of type `number`. In any case, when your screen development is done, you should test it over a big range of different screens as shown below in the [How do I know it works for all devices ?](#example) section.
 * There are 2 more methods to use if you want to support responsiveness along with orientation change. These are `listenOrientationChange` and `removeOrientationListener`. To see how to use them, check example number 3.
 * You can use this package along with `styled-components`. To see how to do that, check example number 2.
 
 # Updates 🚀
-* `widthPercentageToDP` and `heightPercentageToDP` methods accept numeric values as well from version 1.2.1 onwards. That being said a width of 53% can now be written both `width: widthPercentageToDP('53%')` and `width: widthPercentageToDP(53)`.
+* `wp` and `hp` methods accept numeric values as well from version 1.2.1 onwards. That being said a width of 53% can now be written both `width: wp('53%')` and `width: wp(53)`.
 
 # Examples
 
 ## 1. How to use with StyleSheet.create() and without orientation change support 
 ```javascript
-import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
+import {wp, hp} from 'react-native-responsive-screen';
 
 class Login extends Component {
   render() {

--- a/examples/responsive-screen-orientation-change/App.js
+++ b/examples/responsive-screen-orientation-change/App.js
@@ -1,51 +1,55 @@
 // packages
-import * as React from 'react';
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import * as React from 'react'
+import { StyleSheet, Text, View, Dimensions } from 'react-native'
 import {
-  widthPercentageToDP,
-  heightPercentageToDP,
+  wp,
+  hp,
   listenOrientationChange,
   removeOrientationListener
-} from 'react-native-responsive-screen';
- 
+} from 'react-native-responsive-screen'
+
 export default class App extends React.Component {
-  componentWillMount() {
-    listenOrientationChange(this);
+  componentWillMount () {
+    listenOrientationChange(this)
   }
 
-  componentWillUnMount() {
-    removeOrientationListener();
+  componentWillUnMount () {
+    removeOrientationListener()
   }
 
-  render() {
+  render () {
     const styles = StyleSheet.create({
       container: {
         flex: 1,
         backgroundColor: 'gray',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: 'center'
       },
       responsiveBox: {
-        width: widthPercentageToDP('84.5%'),
-        height: heightPercentageToDP('17%'),
+        width: wp('84.5%'),
+        height: hp('17%'),
         borderWidth: 2,
         borderColor: 'orange',
         flexDirection: 'column',
-        justifyContent: 'space-around' 
+        justifyContent: 'space-around'
       },
       text: {
         color: 'white'
       }
-    });
+    })
 
     return (
       <View style={styles.container}>
         <View style={styles.responsiveBox}>
-          <Text style={styles.text}>This box is always of 84.5% width and 17% height.</Text>
-          <Text style={styles.text}>Test it by running this example repo in phones/
-            emulators with screens of various dimensions and pixel per inch (ppi).</Text>
+          <Text style={styles.text}>
+            This box is always of 84.5% width and 17% height.
+          </Text>
+          <Text style={styles.text}>
+            Test it by running this example repo in phones/ emulators with
+            screens of various dimensions and pixel per inch (ppi).
+          </Text>
         </View>
       </View>
-    );
+    )
   }
 }

--- a/examples/responsive-screen-orientation-change/README.md
+++ b/examples/responsive-screen-orientation-change/README.md
@@ -8,8 +8,8 @@ In order to detect orientation change, there are 2 differences from the simple c
 
 ```javascript
 import {
-  widthPercentageToDP as wp,
-  heightPercentageToDP as hp,
+  wp as wp,
+  hp as hp,
   listenOrientationChange as lor,
   removeOrientationListener as rol
 } from 'react-native-responsive-screen';

--- a/examples/responsive-screen-styled-components/App.js
+++ b/examples/responsive-screen-styled-components/App.js
@@ -1,20 +1,22 @@
 // packages
-import * as React from 'react';
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
-import { widthPercentageToDP, heightPercentageToDP } from 'react-native-responsive-screen';
-import styled from 'styled-components';
- 
+import * as React from 'react'
+import { StyleSheet, Text, View, Dimensions } from 'react-native'
+import { wp, hp } from 'react-native-responsive-screen'
+import styled from 'styled-components'
+
 export default class App extends React.Component {
-  render() {
+  render () {
     return (
       <Container>
         <ResponsiveBox>
           <DemoText>This box is always of 84.5% width and 17% height.</DemoText>
-          <DemoText>Test it by running this example repo in phones/
-            emulators with screens of various dimensions and pixel per inch (ppi).</DemoText>
+          <DemoText>
+            Test it by running this example repo in phones/ emulators with
+            screens of various dimensions and pixel per inch (ppi).
+          </DemoText>
         </ResponsiveBox>
       </Container>
-    );
+    )
   }
 }
 
@@ -23,17 +25,17 @@ const Container = styled.View`
   background-color: gray;
   align-items: center;
   justify-content: center;
-`;
+`
 
 const ResponsiveBox = styled.View`
-  width: ${widthPercentageToDP('84.5%')};
-  height: ${heightPercentageToDP('17%')};
+  width: ${wp('84.5%')};
+  height: ${hp('17%')};
   border-width: 2;
   border-color: orange;
   flex-direction: column;
-  justify-content: space-around; 
-`;
+  justify-content: space-around;
+`
 
 const DemoText = styled.Text`
   color: white;
-`;
+`

--- a/examples/responsive-screen-styled-components/README.md
+++ b/examples/responsive-screen-styled-components/README.md
@@ -3,7 +3,7 @@ This is an example repository that contains a sample setup of react-native-respo
 # Usage
 
 ```javascript
-import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
+import {wp, hp} from 'react-native-responsive-screen';
 import styled from 'styled-components';
 
 class Login extends Component {

--- a/examples/responsive-screen/App.js
+++ b/examples/responsive-screen/App.js
@@ -1,19 +1,23 @@
 // packages
-import * as React from 'react';
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
-import {widthPercentageToDP, heightPercentageToDP} from 'react-native-responsive-screen';
- 
+import * as React from 'react'
+import { StyleSheet, Text, View, Dimensions } from 'react-native'
+import { wp, hp } from 'react-native-responsive-screen'
+
 export default class App extends React.Component {
-  render() {
+  render () {
     return (
       <View style={styles.container}>
         <View style={styles.responsiveBox}>
-          <Text style={styles.text}>This box is always of 84.5% width and 17% height.</Text>
-          <Text style={styles.text}>Test it by running this example repo in phones/
-            emulators with screens of various dimensions and pixel per inch (ppi).</Text>
+          <Text style={styles.text}>
+            This box is always of 84.5% width and 17% height.
+          </Text>
+          <Text style={styles.text}>
+            Test it by running this example repo in phones/ emulators with
+            screens of various dimensions and pixel per inch (ppi).
+          </Text>
         </View>
       </View>
-    );
+    )
   }
 }
 
@@ -22,17 +26,17 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: 'gray',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'center'
   },
   responsiveBox: {
-    width: widthPercentageToDP('84.5%'),
-    height: heightPercentageToDP('17%'),
+    width: wp('84.5%'),
+    height: hp('17%'),
     borderWidth: 2,
     borderColor: 'orange',
     flexDirection: 'column',
-    justifyContent: 'space-around' 
+    justifyContent: 'space-around'
   },
   text: {
     color: 'white'
   }
-});
+})

--- a/examples/responsive-screen/README.md
+++ b/examples/responsive-screen/README.md
@@ -2,7 +2,7 @@ This is an example repository that contains a sample setup of `react-native-resp
 
 # Usage
 ```javascript
-import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
+import {wp, hp} from 'react-native-responsive-screen';
 
 class Login extends Component {
   render() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,10 @@
 declare module 'react-native-responsive-screen' {
   import { Component } from 'react';
 
-  export function widthPercentageToDP(widthPercent: string | number): number;
-  export function heightPercentageToDP(heightPercent: string | number): number;
+  export function wp(widthPercent: string | number): number;
+  export function hp(heightPercent: string | number): number;
   export function listenOrientationChange(screenClassComponent: Component<any, any>): void;
   export function removeOrientationListener(): void;
+  export function widthPercentageToDP(widthPercent: string | number): number;
+  export function heightPercentageToDP(heightPercent: string | number): number;
 }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ let screenHeight = Dimensions.get('window').height;
  *                               along with the percentage symbol (%).
  * @return {number}              The calculated dp depending on current device's screen width.
  */
-const widthPercentageToDP = widthPercent => {
+const wp = widthPercent => {
   // Parse string percentage input and convert it to number.
   const elemWidth = typeof widthPercent === "number" ? widthPercent : parseFloat(widthPercent);
 
@@ -28,7 +28,7 @@ const widthPercentageToDP = widthPercent => {
  *                                along with the percentage symbol (%).
  * @return {number}               The calculated dp depending on current device's screen height.
  */
-const heightPercentageToDP = heightPercent => {
+const hp = heightPercent => {
   // Parse string percentage input and convert it to number.
   const elemHeight = typeof heightPercent === "number" ? heightPercent : parseFloat(heightPercent);
 
@@ -69,9 +69,23 @@ const removeOrientationListener = () => {
   Dimensions.removeEventListener('change', () => {});
 };
 
+// deprecated
+const widthPercentageToDP = (widthPercent) => {
+  console.warn('widthPercentageToDP is deprecated and will be removed in the next major version. Use wp instead. ')
+  return wp(widthPercent)
+}
+
+// deprecated
+const heightPercentageToDP = (heightPercent) => {
+  console.warn('heightPercentageToDP is deprecated and will be removed in the next major version. Use hp instead. ')
+  return hp(heightPercent)
+}
+
 export {
+  wp,
+  hp,
+  listenOrientationChange,
+  removeOrientationListener,
   widthPercentageToDP,
   heightPercentageToDP,
-  listenOrientationChange,
-  removeOrientationListener
 };


### PR DESCRIPTION
Hi marudy!
Thank you for creating awesome library.

I think below shorthand make this library greater.

import { wp, hp } from 'react-native-responsive-screen'
